### PR TITLE
add schema-registry-kafkaconnect-converter-1.1.23.jar

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java temurin-11.0.27+6

--- a/build.gradle
+++ b/build.gradle
@@ -73,4 +73,8 @@ subprojects {
       }
     }
   }
+
+  dependencies {
+    implementation 'software.amazon.glue:schema-registry-kafkaconnect-converter:1.1.23'
+  }
 }


### PR DESCRIPTION
- Add schema-registry-kafkaconnect-converter-1.1.23.jar to access AWS Glue Schema Registry from MSK Connector
- Specify the Java version that worked successfully